### PR TITLE
Кнопка "Просмотрено" для эпизодов

### DIFF
--- a/justice.js
+++ b/justice.js
@@ -159,7 +159,9 @@ function start_content_script() {
         console.log('Licensed anime page!')
         let url = location.href.replace('shikimori', 'play.shikimori') + '/video_online/'
         if($('.current-episodes').length) {
-            url += $('.current-episodes').text()
+            let current_episode_text = $('.current-episodes').text()
+            let next_episode = Number(current_episode_text)+1
+            url += String(next_episode)
         }
         else {
             url += '1'

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "I Heard You Like License",
     "description": "Возвращает shikimori к жизни",
-    "version": "1.0",
+    "version": "1.0.1",
     "icons": {"64": "logo.png"},
     "permissions": [
         "proxy",


### PR DESCRIPTION
Как оказалось, без нее стало слишком непривычно.

![image](https://user-images.githubusercontent.com/2355735/44866489-1ed1ac00-acd1-11e8-915f-8b5fa06cb987.png)

Чтобы все работало без серверной части, пришлось пойти на относительный хак: Шикимори на главной странице аниме позволяет дергать _user rates api_ без токена, но для этого нужно знать _user rate id_ аниме (который, к сожалению, не совпадает с _anime id_).

Сам хак: при заходе на страницу лицензированного аниме, пользователь добавляет аниме в статус "Смотрю" / "Запланировано", расширение берет ссылку и уже может без проблем увеличивать счетчик просмотренных серий.

В качестве хранилища взял Chrome Storage. Не смог приспособить Local Storage для нескольких доменов (shikimori.org, play.shikimori.org), плюс Chrome, если я правильно понимаю, может синхронизировать эти данные между браузерами.

**Недочеты**:
- Если пользователь начинает тайтл, который не добавлен в его списки, то он должен поставить статус "Смотрю" / "Запланировано" **и затем перегрузить страницу**. User Rates ID берется только после завершения загрузки страницы, но к этому моменту он еще не загрузился из AJAX. Бегло пробежался по Сети в поисках решения, но не нашел годного кроссбраузерного решения (MutationObserver пока отложен в сторону).

- Отправка инкремента счетчика серий и переход к следующей **не синхронизированы**. За инкремент отвечает jquery-ujs, а переход дергается из самого расширения. Поленился в поиске и пока **поставил просто 1-у секунду ожидания до перехода**. Не думаю, что это может плохо отработать, но само решение жуткий костыль. Не знаю, как правильно (красиво) сделать событие при завершении запроса на инкремент.

- Если нажать на кнопку уже просмотренного эпизода, то счетчик увеличиться, а пользователь перейдет к следующем эпизоду. Т.е. расширение не хранит информацию о том, сколько пользователь посмотрел серий: только инкремент с переходом к следующему эпизоду.